### PR TITLE
create CoinDetail "Type" enum for the Link class to keep things more robust

### DIFF
--- a/src/main/java/io/cryptocontrol/cryptonewsapi/models/CoinDetail.java
+++ b/src/main/java/io/cryptocontrol/cryptonewsapi/models/CoinDetail.java
@@ -61,11 +61,9 @@ public class CoinDetail {
         @SerializedName("link")
         private String link;
 
-
-        public String getType() {
-            return type;
+        public Type getType() {
+            return Type.getTypeById(type);
         }
-
 
         public String getName() {
             return name;
@@ -76,5 +74,27 @@ public class CoinDetail {
             return link;
         }
 
+    }
+
+    enum Type{
+        TWITTER("twitter"), WEBSITE("website"),
+        REDDIT("reddit"), GITHUB("github"),
+        UNKNOWN("unknown"), DEFAULT(UNKNOWN.typeId);
+
+        private final String typeId;
+
+        Type(String typeId) {
+            this.typeId = typeId;
+        }
+
+        public static Type getTypeById(String id){
+            for (Type type : values()) {
+                if(id.equalsIgnoreCase(type.typeId)){
+                    return type;
+                }
+            }
+
+            return DEFAULT;
+        }
     }
 }


### PR DESCRIPTION
@senamakel i thought that this might be more robust than using the Link type as a string directly as this is handled by the enum now it should make it clear for other devs to know the available types.

Not sure if i am breaking something with this change so please do check it out and let me know what you think